### PR TITLE
Prefer vim.health in health check.

### DIFF
--- a/lua/lspupdate/util.lua
+++ b/lua/lspupdate/util.lua
@@ -91,7 +91,7 @@ local function first_path()
 end
 local function health()
   local config = require("lspupdate.config")
-  local health0 = require("health")
+  local health0 = vim.health or require("health")
   local start = health0.report_start
   local ok = health0.report_ok
   local err0 = health0.report_error


### PR DESCRIPTION
When running `:checkhealth` there is an exception trying to load `'health'`. The nvim documentation give instructions that include the use of `vim.health.*` functions for the purposes this require provides. This PR should use that as the first resort.

```
==============================================================================
lspupdate: require("lspupdate.health").check()

- ERROR Failed to run healthcheck for "lspupdate" plugin. Exception:
  function health#check, line 25
  Vim(eval):E5108: Error executing lua ...al/share/nvim/lazy/nvim-lspupdate/lua/lspupdate/util.lua:94: module 'health' not found:
  no field package.preload['health']
  cache_loader: module health not found
  cache_loader_lib: module health not found
  no file './health.lua'
  no file '/opt/homebrew/share/luajit-2.1/health.lua'
  no file '/usr/local/share/lua/5.1/health.lua'
  no file '/usr/local/share/lua/5.1/health/init.lua'
  no file '/opt/homebrew/share/lua/5.1/health.lua'
  no file '/opt/homebrew/share/lua/5.1/health/init.lua'
  no file './health.so'
  no file '/usr/local/lib/lua/5.1/health.so'
  no file '/opt/homebrew/lib/lua/5.1/health.so'
  no file '/usr/local/lib/lua/5.1/loadall.so'
  stack traceback:
  [C]: in function 'require'
  ...al/share/nvim/lazy/nvim-lspupdate/lua/lspupdate/util.lua:94: in function 'check'
  [string "luaeval()"]:1: in main chunk

```